### PR TITLE
Help parameter correction

### DIFF
--- a/CliRunner/Program.fs
+++ b/CliRunner/Program.fs
@@ -442,13 +442,15 @@ type CliParams =
                printfn $"Parsed: \n\n {this} \n\n
                     Usage
                     =====
-                    dotnet run id=<id:string> runs=<runsCount: int> agents=<agents: int> stage1=<stage1Round: int>*<mode:string> stage2=<stage2Round: int>*<mode:string> reds=<redAgentSetup: int list> hawks=<expectedHawkPercents: int list>
+                    dotnet run id=<id:string> runs=<runsCount: int> agents=<agents: int> stage1=<stage1Round: int>-<mode:string> stage2=<stage2Round: int>-<mode:string> reds=<redAgentSetup: int list> hawks=<expectedHawkPercents: int list>
 
                     id and stage1 are optional. Other parameters are mandatory
 
                     Example
                     =======
-                    dotnet run id=test runs=100 agents=200 stage2=250*stage2_nmse red=10;50;90 hawk=10;30;50;70;90
+                    dotnet run id=test runs=100 agents=200 stage2=250-stage2_nmse red=10,50,90 hawk=10,30,50,70,90
+
+                    For more examples, see README.md
                     "
                1
 

--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ where:
 * `agents` (integer) How many agents is used in each simulation". Example `200`
 * `stage2` (specific format: `integer`-`mode name`) How many rounds of simulation is ran with given model. Example `250-stage2_dove` means 250 rounds with stage2_dove mode
 * `stage1` (OPTIONAL; specific format: `integer`-`mode name`) How many rounds of simulation is ran with given model. Example `250-stage2_dove` means 250 rounds with stage2_dove mode
-* `red` (integer OR integer list, delimiter = ';'). Example `"10;30;50"` or just `10`. Note: Use qoutes (") for the list
-* `hawk` (integer list, delimiter = ';'). Example `"10;30;50;70;90"` or `90`. Note: Use qoutes (") for the list
+* `red` (integer OR integer list, delimiter = ','). Example `"10,30,50"` or just `10`. Note: Use qoutes (") for the list
+* `hawk` (integer list, delimiter = ','). Example `"10,30,50,70,90"` or `90`. Note: Use qoutes (") for the list
 
 Simulation is run once for each red and for each hawk setups. 
 


### PR DESCRIPTION
The current command-line tool help was incorrect and didn't work. This fixes it to be consistent with README.md